### PR TITLE
Preserve SANotificationRegistrationURL case

### DIFF
--- a/Sources/TiqrCoreObjC/Classes/NotificationRegistration.m
+++ b/Sources/TiqrCoreObjC/Classes/NotificationRegistration.m
@@ -61,7 +61,7 @@ static NotificationRegistration *sharedInstance = nil;
 	    body = [NSString stringWithFormat:@"deviceToken=%@&notificationToken=%@&language=%@", escapedDeviceToken, escapedNotificationToken, escapedLanguage];				
 	}
     
-    NSString *url = [[[TiqrConfig valueForKey:@"SANotificationRegistrationURL"] stringByAppendingString:TiqrConfig.appName] lowercaseString];
+    NSString *url = [[TiqrConfig valueForKey:@"SANotificationRegistrationURL"] stringByAppendingString:[TiqrConfig.appName lowercaseString]];
 	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
 	[request setCachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData];
 	[request setTimeoutInterval:15.0];


### PR DESCRIPTION
Only lowercase the appName.

The url to POST to the tx.tiqr.org token exchange server contains an "appId" query string that is case sensitive. When this parameter is not present the tx.tiqr.org server returns HTTP 400 status code with "appId param required" in the body. The tiqr client then proceeds to use this error string as the device notification address. This means the tiqr server can then no longer sent push notifications to the device.