### PR TITLE
TIQR-296: Add git commit to about

### DIFF
--- a/Sources/TiqrCoreObjC/Classes/AboutViewController.m
+++ b/Sources/TiqrCoreObjC/Classes/AboutViewController.m
@@ -68,7 +68,12 @@
     [self.okButton setTitle:[Localization localize:@"ok_button" comment:@"OK"] forState:UIControlStateNormal];
     self.okButton.layer.cornerRadius = 5;
 
-    self.versionLabel.text = [NSString stringWithFormat:[Localization localize:@"app_version" comment:@"App version: %@"], TiqrConfig.appVersion];
+    self.versionLabel.text = [NSString stringWithFormat:[Localization localize:@"app_version" comment:@"App version: %@"], TiqrConfig.appAndBuildVersion];
+    
+    // Tap to reveal more technical version
+    UITapGestureRecognizer *revealTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showGitReleaseVersion:)];
+    [self.versionLabel addGestureRecognizer: revealTapRecognizer];
+    self.versionLabel.userInteractionEnabled = YES;
     
     if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
         self.edgesForExtendedLayout = UIRectEdgeNone;
@@ -104,6 +109,10 @@
 
 - (IBAction)done {
     [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (IBAction)showGitReleaseVersion:(id)sender {
+    self.versionLabel.text = [NSString stringWithFormat:[Localization localize:@"app_version" comment:@"App version: %@"], TiqrConfig.gitReleaseVersion];
 }
 
 - (void)viewSafeAreaInsetsDidChange {

--- a/Sources/TiqrCoreObjC/Classes/TiqrConfig.h
+++ b/Sources/TiqrCoreObjC/Classes/TiqrConfig.h
@@ -37,5 +37,8 @@
 
 @property (class, copy, readonly) NSString *appName;
 @property (class, copy, readonly) NSString *appVersion;
+@property (class, copy, readonly) NSString *buildVersion;
+@property (class, copy, readonly) NSString *appAndBuildVersion;
+@property (class, copy, readonly) NSString *gitReleaseVersion;
 
 @end

--- a/Sources/TiqrCoreObjC/Classes/TiqrConfig.m
+++ b/Sources/TiqrCoreObjC/Classes/TiqrConfig.m
@@ -228,4 +228,16 @@
     return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
 }
 
++ (NSString *)buildVersion {
+    return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+}
+
++ (NSString *)appAndBuildVersion {
+    return [NSString stringWithFormat:@"%@ (%@)", [self appVersion], [self buildVersion]];
+}
+
++ (NSString *)gitReleaseVersion {
+    return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"TIQRGitReleaseVersion"];
+}
+
 @end


### PR DESCRIPTION
Apple has some restrictions on what are considered valid version and build numbers. 

I've added a script that sets info based on the latest tag and current commit git describe --tags --always which produces output like 1.1-3-gabc123 where 1.1 is the latest tag, 3 the number of commits since and abc123 the start of the current commit.

In the about screen I show the current version and build number, e.g. 1.1 (2) now. A tap on it reveals the more technical git release version.

![Simulator Screen Shot - iPhone SE (1st generation) - 2022-11-17 at 12 19 28](https://user-images.githubusercontent.com/68731/202435740-0281d121-f4e5-49c3-bd65-03f1261377e0.png)
![Simulator Screen Shot - iPhone SE (1st generation) - 2022-11-17 at 12 19 33](https://user-images.githubusercontent.com/68731/202435770-00e2720d-de56-4b6e-86c4-7c4f71112dff.png)
