### PR TITLE
TIQR-331/332/333: Fix for crashes

### DIFF
--- a/Sources/TiqrCoreObjC/Classes/IdentityTableViewCell.m
+++ b/Sources/TiqrCoreObjC/Classes/IdentityTableViewCell.m
@@ -72,6 +72,25 @@
     return self;
 }
 
+// Validates if the rect has no infinite or NaN numbers
++ (BOOL)isValidRect:(CGRect)rect {
+    CGPoint origin = rect.origin;
+    if (isnormal(origin.x) == NO) {
+        return NO;
+    }
+    if (isnormal(origin.y) == NO) {
+        return NO;
+    }
+    CGSize size = rect.size;
+    if (isnormal(size.width) == NO) {
+        return NO;
+    }
+    if (isnormal(size.height) == NO) {
+        return NO;
+    }
+    return YES;
+}
+
 - (void)layoutSubviews {
 	[super layoutSubviews];		
 	
@@ -96,9 +115,11 @@
 	imageFrame.origin.x = 30;
 	imageFrame.origin.y = padding + ((maxHeight - height) / 2);
 	imageFrame.size.width = width;
-	imageFrame.size.height = height;	
-	self.imageView.frame = imageFrame;
-	
+	imageFrame.size.height = height;
+    if ([IdentityTableViewCell isValidRect:imageFrame]) {
+        self.imageView.frame = imageFrame;
+    }
+    
 	CGFloat textPaddingX = 30.0;
     CGFloat textPaddingY = 0.0;
 	CGFloat textOriginX = imageFrame.origin.x + width + textPaddingX;
@@ -109,19 +130,25 @@
 	textFrame.origin.x = textOriginX;	
     textFrame.origin.y = textOriginY;
 	textFrame.size.width = self.frame.size.width - textFrame.origin.x - textPaddingX - 20.0;
-	self.textLabel.frame = textFrame;
-	
+    if ([IdentityTableViewCell isValidRect:textFrame]) {
+        self.textLabel.frame = textFrame;
+    }
+    
 	CGRect detailTextFrame = self.detailTextLabel.frame;
 	detailTextFrame.origin.x = textOriginX;	
     detailTextFrame.origin.y = textOriginY + textFrame.size.height + textPaddingY;
 	detailTextFrame.size.width = self.frame.size.width - detailTextFrame.origin.x - textPaddingX - 20.0;
-	self.detailTextLabel.frame = detailTextFrame;
+    if ([IdentityTableViewCell isValidRect:textFrame]) {
+        self.detailTextLabel.frame = detailTextFrame;
+    }
     
 	CGRect blockedFrame = self.blockedLabel.frame;
 	blockedFrame.origin.x = textOriginX;	
     blockedFrame.origin.y = textOriginY + textFrame.size.height + textPaddingY + detailTextFrame.size.height + textPaddingY;
 	blockedFrame.size.width = self.frame.size.width - blockedFrame.origin.x - textPaddingX - 20.0;
-	self.blockedLabel.frame = blockedFrame;
+    if ([IdentityTableViewCell isValidRect:blockedFrame]) {
+        self.blockedLabel.frame = blockedFrame;
+    }
 }
 
 - (void)setIdentity:(Identity *)identity {

--- a/Sources/TiqrCoreObjC/Classes/NotificationRegistration.m
+++ b/Sources/TiqrCoreObjC/Classes/NotificationRegistration.m
@@ -61,7 +61,6 @@ NSString* const KEY_DEVICE_TOKEN = @"TiqrDeviceToken";
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *key = [self isTokenExchangeEnabled] ? KEY_NOTIFICATION_TOKEN : KEY_DEVICE_TOKEN;
 	[defaults setValue:notificationToken forKey: key];
-	[defaults synchronize];
 }
 
 - (NSString *)notificationToken {

--- a/Sources/TiqrCoreObjC/Classes/ScanViewController.m
+++ b/Sources/TiqrCoreObjC/Classes/ScanViewController.m
@@ -255,17 +255,18 @@
     self.decoding = NO;
     
 #if HAS_AVFF
+    AVCaptureSession *currentCaptureSession = self.captureSession;
     dispatch_async(self.sessionQueue, ^{
-        [self.captureSession stopRunning];
+        [currentCaptureSession stopRunning];
 
-        if ([self.captureSession.inputs count]) {
-            AVCaptureInput* input = [self.captureSession.inputs objectAtIndex:0];
-            [self.captureSession removeInput:input];
+        if ([currentCaptureSession.inputs count]) {
+            AVCaptureInput* input = [currentCaptureSession.inputs objectAtIndex:0];
+            [currentCaptureSession removeInput:input];
         }
         
-        if ([self.captureSession.outputs count]) {
-            AVCaptureVideoDataOutput* output = (AVCaptureVideoDataOutput *)[self.captureSession.outputs objectAtIndex:0];
-            [self.captureSession removeOutput:output];
+        if ([currentCaptureSession.outputs count]) {
+            AVCaptureVideoDataOutput* output = (AVCaptureVideoDataOutput *)[currentCaptureSession.outputs objectAtIndex:0];
+            [currentCaptureSession removeOutput:output];
         }
     });
     
@@ -325,10 +326,6 @@
 - (void)listIdentities {
     IdentityListViewController *viewController = [[IdentityListViewController alloc] init];
     [self.navigationController pushViewController:viewController animated:YES];
-}
-
-- (void)dealloc {
-    [self stopCapture];
 }
 
 @end

--- a/Sources/TiqrCoreObjC/include/NotificationRegistration.h
+++ b/Sources/TiqrCoreObjC/include/NotificationRegistration.h
@@ -37,7 +37,7 @@
 #import <UIKit/UIKit.h>
 
 @interface NotificationRegistration : NSObject {
-	NSMutableData *responseData;
+
 }
 
 /**


### PR DESCRIPTION
The IdentityCell should be rewritten with more modern layout instead manual calculations. Now mostly just trying not to choke on NaN values.

The NotificationRegistration now uses more modern API so no need to stitch NSData's together anymore and it is now safe to call it while a previous attempt might still be running.

Stopping capture in dealloc should never be needed. It shouldn't be done twice, now not capturing self in block but only the captureSession itself.