### PR TITLE
TIQR-345-347: Minor bugfixes

### DIFF
--- a/Sources/TiqrCoreObjC/Classes/AuthenticationPINViewController.m
+++ b/Sources/TiqrCoreObjC/Classes/AuthenticationPINViewController.m
@@ -97,7 +97,7 @@
                     self.challenge.identity.blocked = @YES;
                     [ServiceContainer.sharedInstance.identityService saveIdentities];
                     
-                    [self presentErrorViewControllerWithError:error];
+                    [self presentErrorViewControllerWithError:error andUserRetryAllowed:NO];
                     break;
                 }
                     
@@ -107,7 +107,7 @@
                         [ServiceContainer.sharedInstance.identityService blockAllIdentities];
                         [ServiceContainer.sharedInstance.identityService saveIdentities];
                         
-                        [self presentErrorViewControllerWithError:error];
+                        [self presentErrorViewControllerWithError:error andUserRetryAllowed:NO];
                     } else {
                         [self clear];
                         [self showErrorWithTitle:[error localizedDescription] message:[error localizedFailureReason]];
@@ -116,7 +116,7 @@
                 }
                     
                 default: {
-                    [self presentErrorViewControllerWithError:error];
+                    [self presentErrorViewControllerWithError:error andUserRetryAllowed:NO];
                     break;
                 }
             }
@@ -124,9 +124,13 @@
     }];
 }
 
-- (void)presentErrorViewControllerWithError:(NSError *)error {
+- (void)presentErrorViewControllerWithError:(NSError *)error andUserRetryAllowed:(BOOL)retryAllowed  {
     UIViewController *viewController = [[ErrorViewController alloc] initWithErrorTitle:[error localizedDescription] errorMessage:[error localizedFailureReason]];
-    [self.navigationController pushViewController:viewController animated:YES];
+    UINavigationController *navController = [self navigationController];
+    if (!retryAllowed) {
+        [navController popToRootViewControllerAnimated: NO];
+    }
+    [navController pushViewController:viewController animated:YES];
 }
 
 

--- a/Sources/TiqrCoreObjC/Classes/PINViewController.m
+++ b/Sources/TiqrCoreObjC/Classes/PINViewController.m
@@ -163,7 +163,7 @@
 
 - (void)clear {
     self.pinTextField.text = @"";
-    self.okButton.enabled = YES;
+    self.okButton.enabled = NO;
 }
 
 @end


### PR DESCRIPTION
The first commit makes sure that the OK button is not enabled by default on the PIN entry screen.
The second commit changes the behavior when you have an invalid challenge error. In this case going back, you will be returned to the home screen of the app.