### PR TITLE
TIQR-385: Fix another english SURFnet page reference

### DIFF
--- a/Sources/TiqrCoreObjC/Classes/TiqrToolbar.m
+++ b/Sources/TiqrCoreObjC/Classes/TiqrToolbar.m
@@ -59,7 +59,7 @@
 }
 
 - (void)surfnet {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.surf.nl/en/"]];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.surf.nl/"]];
 }
 
 @end


### PR DESCRIPTION
We also link to the SURFnet site from the bottom bar, which I did not notice, correcting it with this PR