### PR TITLE
TIQR-434: Fix crash when exiting scan screen

### DIFF
--- a/Sources/TiqrCoreObjC/Classes/ScanViewController.m
+++ b/Sources/TiqrCoreObjC/Classes/ScanViewController.m
@@ -307,11 +307,16 @@
 }
 
 - (void)processChallenge:(NSString *)scanResult {
-    [MBProgressHUD showHUDAddedTo:self.navigationController.view animated:YES];
+    UIView *navigationControllerView = self.navigationController.view;
+    if (navigationControllerView == nil) {
+        // User already left the screen.
+        return;
+    }
+    [MBProgressHUD showHUDAddedTo:navigationControllerView animated:YES];
     
     [ServiceContainer.sharedInstance.challengeService startChallengeFromScanResult:scanResult completionHandler:^(TIQRChallengeType type, NSObject * _Nullable challengeObject, NSError * _Nullable error) {
         
-        [MBProgressHUD hideHUDForView:self.navigationController.view animated:YES];
+        [MBProgressHUD hideHUDForView:navigationControllerView animated:YES];
         
         if (type != TIQRChallengeTypeInvalid) {
             [self pushViewControllerForChallenge:challengeObject Type:type];


### PR DESCRIPTION
This crash could happen when you left the scan screen immediately after a QR has been recognized, but the next screen was not opened yet.